### PR TITLE
fix: prevent default redirect on submit

### DIFF
--- a/components/AuthCard.tsx
+++ b/components/AuthCard.tsx
@@ -65,7 +65,8 @@ export function AuthCard() {
         return passwordRegex.test(password);
     };
 
-    const handleSubmit = async () => {
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
         if (!isEmailValid(email)) {
             setShowEmailError(true);
             return;


### PR DESCRIPTION
This PR aims to fix an issue during sign up where the page redirects after form submission, caused by the default behaviour of a button that has `type="submit"` in a `<form>` tag

### implementation
`event.preventDefault()`